### PR TITLE
FIX: Replace deprecated np.object with builtin object

### DIFF
--- a/mpl_playback/record.py
+++ b/mpl_playback/record.py
@@ -56,7 +56,7 @@ def _find_obj(names, objs, obj, accessors):
         if isinstance(maybe, np.ndarray):
             # gotta special case otherwise potential
             # for ValueErrors when doing obj in numpy-array
-            if maybe.dtype == np.object:
+            if maybe.dtype == object:
                 if obj in maybe:
                     return name, int(np.where(maybe == obj)[0][0])
         elif isinstance(maybe, (list, tuple)) and obj in maybe:

--- a/mpl_playback/util.py
+++ b/mpl_playback/util.py
@@ -37,7 +37,7 @@ def listify_dict(d):
     objs = []
     for k, v in d.items():
         if isinstance(v, (list, tuple, dict, np.ndarray, Axes, SubplotBase, Figure)):
-            if isinstance(v, np.ndarray) and not v.dtype == np.object:
+            if isinstance(v, np.ndarray) and not v.dtype == object:
                 continue
             if "__" in k:
                 continue


### PR DESCRIPTION
## Problem
np.object was removed in NumPy 1.24. This causes an AttributeError
on any modern NumPy installation, making mpl-playback completely
broken out of the box.

## Fix
Replace np.object with the builtin object in two places:
- mpl_playback/util.py: listify_dict()
- mpl_playback/record.py: line 59

## Tested on
- NumPy 1.26.4
- Python 3.12.6
- Matplotlib 3.10.7